### PR TITLE
Support wrapping all suites in a top-level suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,25 @@ Then call mocha with:
 `mocha --reporter mocha-teamcity-reporter-v2 test`
 
 ## Customisation:
-Can set flowId like:  
+
+### TeamCity flowId
+
+Can set flowId like:
 `mocha test --reporter mocha-teamcity-reporter-v2 --reporter-options flowId=gobbledygook`
+
+### Top-level suite name
+
+Can set a top-level suite name, which will wrap all other suites.
+
+This is useful for reading test output when running multiple suites in a single build:
+
+* Set with reporter-options:
+
+`mocha test --reporter mocha-teamcity-reporter-v2 --reporter-options topLevelSuite=top-level-suite-name`
+
+* Set with environment variable
+
+`MOCHA_TEAMCITY_TOP_LEVEL_SUITE='top-level-suite-name' mocha test --reporter mocha-teamcity-reporter-v2`
 
 ## Contributions
 * Always Welcome

--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -79,9 +79,16 @@ function Teamcity(runner, options) {
 	(reporterOptions.flowId) ? flowId = reporterOptions.flowId : flowId =  process.env['MOCHA_TEAMCITY_FLOWID'] || processPID;
 	Base.call(this, runner);
 	let stats = this.stats;
+	const topLevelSuite = reporterOptions.topLevelSuite || process.env['MOCHA_TEAMCITY_TOP_LEVEL_SUITE'];
 
 	runner.on('suite', function (suite) {
-		if (suite.root) return;
+		if (suite.root) {
+			if (topLevelSuite) {
+				log(formatString(SUITE_START, topLevelSuite, flowId));
+			}
+			return;
+		}
+
 		suite.startDate = new Date();
 		log(formatString(SUITE_START, suite.title, flowId));
 	});
@@ -108,6 +115,10 @@ function Teamcity(runner, options) {
 	});
 
 	runner.on('end', function () {
+		if (topLevelSuite) {
+			log(formatString(SUITE_END, topLevelSuite, stats.duration, flowId));
+		}
+
 		log(formatString(SUITE_END, 'mocha.suite', stats.duration, flowId));
 	});
 }

--- a/test/functional/helpers.js
+++ b/test/functional/helpers.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+function logMochaOutput(stdout, stderr) {
+	console.log('Observed Reporter Output');
+	console.log('|#####################|');
+	console.log(stdout);
+	console.log('|#####################|');
+
+	if (stderr) {
+		console.log('|#####################|');
+		console.log('stderr:');
+		console.log('|#####################|');
+		console.log(stderr);
+		console.log('|#####################|');
+	}
+}
+
+
+function getMochaPath() {
+	if (os.platform() === 'win32') {
+		return path.resolve('node_modules', '.bin', 'mocha.cmd');
+	} else {
+		return path.resolve('node_modules', '.bin', 'mocha');
+	}
+}
+
+module.exports = {
+	logMochaOutput,
+	getMochaPath
+};

--- a/test/functional/testOutput.js
+++ b/test/functional/testOutput.js
@@ -5,15 +5,10 @@
 'use strict';
 const {execFile} = require('child_process');
 const assert = require('assert');
-const os = require('os');
-const path = require('path');
 
-let internalMochaPath;
-if (os.platform() === 'win32') {
-	internalMochaPath = path.resolve('node_modules', '.bin', 'mocha.cmd');
-} else {
-	internalMochaPath = path.resolve('node_modules', '.bin', 'mocha');
-}
+const { logMochaOutput, getMochaPath } = require('./helpers');
+
+const internalMochaPath = getMochaPath();
 
 describe('Check TeamCity Output is correct', function () {
 	let teamCityStdout, teamCityStderr, teamCityOutputArray;
@@ -23,10 +18,7 @@ describe('Check TeamCity Output is correct', function () {
 			teamCityStdout = stdout;
 			teamCityStderr = stderr;
 			teamCityOutputArray = stdout.split('\n');
-			console.log('Observed Reporter Output');
-			console.log('|#####################|');
-			console.log(stdout);
-			console.log('|#####################|');
+			logMochaOutput(stdout, stderr);
 			done();
 		});
 	});

--- a/test/functional/topLevelSuiteOutput.js
+++ b/test/functional/topLevelSuiteOutput.js
@@ -1,0 +1,89 @@
+'use strict';
+const {execFile} = require('child_process');
+const assert = require('assert');
+const { logMochaOutput, getMochaPath } = require('./helpers');
+const internalMochaPath = getMochaPath();
+
+describe('Check TeamCity Output is correct with outer suite', function () {
+	let teamCityStdout, teamCityStderr, teamCityOutputArray;
+	function verifyResults() {
+		it('stdout output should exist', function () {
+			assert.ok(teamCityStdout, 'has output');
+			assert.ok(teamCityOutputArray, 'array of output is populated');
+			assert.ok(teamCityOutputArray.length >= 10, 'at least 10 lines of output');
+		});
+
+		it('stderr output should not exist', function () {
+			assert.ok(teamCityStderr.length === 0);
+		});
+
+		it('Prefix suite start is present', function () {
+			const rowToCheck = teamCityOutputArray[0];
+			assert.ok(/##teamcity\[testSuiteStarted/.test(rowToCheck));
+			assert.ok(/name='test-outer-suite-name'/.test(rowToCheck));
+			assert.ok(/flowId=/.test(rowToCheck));
+			assert.ok(/]/.test(rowToCheck));
+		});
+
+		it('Prefix suite end is present', function () {
+			const rowToCheck = teamCityOutputArray[11];
+			assert.ok(/##teamcity\[testSuiteFinished/.test(rowToCheck));
+			assert.ok(/name='mocha.suite'/.test(rowToCheck));
+			assert.ok(/duration=/.test(rowToCheck));
+			assert.ok(/flowId=/.test(rowToCheck));
+			assert.ok(/]/.test(rowToCheck));
+		});
+
+		it('Suite Root Finished is OK', function () {
+			const rowToCheck = teamCityOutputArray[11];
+			assert.ok(/##teamcity\[testSuiteFinished/.test(rowToCheck));
+			assert.ok(/name='mocha.suite'/.test(rowToCheck));
+			assert.ok(/duration=/.test(rowToCheck));
+			assert.ok(/flowId=/.test(rowToCheck));
+			assert.ok(/]/.test(rowToCheck));
+		});
+	}
+
+	describe('specified as an env var', function () {
+		before(function (done) {
+			const opts = {
+				env: Object.assign({
+					MOCHA_TEAMCITY_TOP_LEVEL_SUITE: 'test-outer-suite-name'
+				}, process.env)
+			};
+
+			execFile(internalMochaPath, [
+				'test/test_data',
+				'--reporter',
+				'lib/teamcity'
+			], opts, (err, stdout, stderr) => {
+				teamCityStdout = stdout;
+				teamCityStderr = stderr;
+				teamCityOutputArray = stdout.split('\n');
+				logMochaOutput(stdout, stderr);
+				done();
+			});
+		});
+		verifyResults();
+	});
+
+	describe('specified with --reporter-options', function () {
+		before(function (done) {
+			execFile(internalMochaPath, [
+				'test/test_data',
+				'--reporter',
+				'lib/teamcity',
+				'--reporter-options',
+				'topLevelSuite=test-outer-suite-name'
+			], (err, stdout, stderr) => {
+				teamCityStdout = stdout;
+				teamCityStderr = stderr;
+				teamCityOutputArray = stdout.split('\n');
+				logMochaOutput(stdout, stderr);
+				done();
+			});
+		});
+		verifyResults();
+	});
+
+});


### PR DESCRIPTION
This helps to sort test output in TC when running many suites in one build.
Not sure if this is a needed feature for anyone else. If not, feel free to close.

I also broke out some helper functions in the tests, so they could be shared with the new tests I added, and made a modification so that stderr from mocha is logged in the tests, if present.
